### PR TITLE
fix: choose lighter dtype for distance and error stored values

### DIFF
--- a/src/macest/classification/models.py
+++ b/src/macest/classification/models.py
@@ -205,7 +205,8 @@ class ModelWithConfidence:
             neighbours = np.array(
                 self.graph[cls].knnQueryBatch(  # type: ignore
                     x_star, k=self._num_neighbours, num_threads=num_threads_available
-                )
+                ),
+                dtype='float32',
             )
             class_dist = neighbours[:, 1, :].clip(min=10 ** -15)
             class_ind = neighbours[:, 0, :].astype(int)
@@ -213,7 +214,8 @@ class ModelWithConfidence:
                 raise ValueError("training_preds_by_class has already been cached")
             class_preds = self.training_preds_by_class[cls]
             class_error = np.array(
-                [class_preds[class_ind[j]] != cls for j in range(x_star.shape[0])]
+                [class_preds[class_ind[j]] != cls for j in range(x_star.shape[0])],
+                dtype='bool',
             )
         else:
             if self.distance_to_neighbours is None:
@@ -507,7 +509,8 @@ class _TrainingHelper(object):
             max_neighbours = np.array(
                 self.model.graph[class_num].knnQueryBatch(  # type: ignore
                     self.x_cal, k=max_nbrs, num_threads=num_threads_available
-                )
+                ),
+                dtype='float32',
             )
             max_dist = max_neighbours[x_cal_len_array, 1]
             max_ind = max_neighbours[x_cal_len_array, 0]
@@ -519,7 +522,8 @@ class _TrainingHelper(object):
                     [
                         cls_preds[ind[j].astype(int)] != class_num
                         for j in range(self.x_cal.shape[0])
-                    ]
+                    ],
+                    dtype='bool',
                 )  # type: ignore
 
                 dist_dict[k] = dist

--- a/src/macest/regression/models.py
+++ b/src/macest/regression/models.py
@@ -156,7 +156,8 @@ class ModelWithPredictionInterval:
         neighbours = np.array(
             self.prec_graph.knnQueryBatch(
                 x_star, k=self._num_neighbours, num_threads=num_threads_available
-            )
+            ),
+            dtype='float32',
         )
         dist = neighbours[:, 1, :]
         ind = neighbours[:, 0, :].astype(int)
@@ -437,7 +438,8 @@ class _TrainingHelper(object):
         max_neighbours = np.array(
             self.prec_graph.knnQueryBatch(
                 self.x_cal, k=int(max_nbrs), num_threads=num_threads_available
-            )
+            ),
+            dtype='float32',
         )
 
         max_dist = max_neighbours[x_cal_len_array, 1]


### PR DESCRIPTION
This PR tries to solve the following problem:
When traning macest on a large dataset, the step of pre-computing distances and errors requires a lot of memory. A simple solution would be to use lighter dtypes: `float32` for distances and `bool` for errors

Signed-off-by: Florent Rambaud <flo.rambaud@gmail.com>