### PR TITLE
feat: ability to use only precomputed point predictions

### DIFF
--- a/src/macest/classification/models.py
+++ b/src/macest/classification/models.py
@@ -164,7 +164,7 @@ class ModelWithConfidence:
         :param x_star: The point(s) at which we want to predict
         :return: A point prediction for the given x_star
         """
-        if point_pred_model is None:
+        if self.point_pred_model is None:
             raise ValueError("Cannot predict as no 'point_pred_model' has been initialized")
         return self.point_pred_model.predict(x_star)
 
@@ -594,7 +594,7 @@ class _TrainingHelper(object):
             self,
             optimiser: Literal["de"] = "de",
             optimiser_args: Optional[Dict[Any, Any]] = None,
-            update_empirical_conflict_constant: bool = False,
+            update_empirical_conflict_constant: bool = True,
     ) -> ModelWithConfidence:
         """
         Fit MACEst model using the calibration data.

--- a/src/macest/classification/models.py
+++ b/src/macest/classification/models.py
@@ -80,7 +80,7 @@ class ModelWithConfidence:
             self,
             x_train: np.ndarray,
             y_train: Iterable[int],
-            point_pred_model: _ClassificationPointPredictionModel = None,
+            point_pred_model: Optional[_ClassificationPointPredictionModel] = None,
             macest_model_params: MacestConfModelParams = MacestConfModelParams(),
             precomputed_neighbour_info: Optional[PrecomputedNeighbourInfo] = None,
             graph: Optional[Dict[int, nmslib.dist.FloatIndex]] = None,

--- a/src/macest/regression/models.py
+++ b/src/macest/regression/models.py
@@ -70,7 +70,7 @@ class ModelWithPredictionInterval:
         self,
         x_train: np.ndarray,
         train_err: np.ndarray,
-        model: _RegressionPointPredictionModel = None,
+        model: Optional[_RegressionPointPredictionModel] = None,
         macest_model_params: MacestPredIntervalModelParams = MacestPredIntervalModelParams(),
         error_dist: Literal["normal", "laplace"] = "normal",
         dist_func: Literal["linear", "error_weighted_poly"] = "linear",

--- a/src/macest/regression/models.py
+++ b/src/macest/regression/models.py
@@ -128,7 +128,7 @@ class ModelWithPredictionInterval:
 
         :return: pred_star : The point prediction for x_star
         """
-        if model is None:
+        if self.model is None:
             raise ValueError("Cannot predict as no 'model' has been initialized")
         pred_star = self.model.predict(x_star)
         return pred_star


### PR DESCRIPTION
This PR adds the ability to train and use a macest model only from precomputed point predictions. This allows to have no reference to the point predcition model in the macest model, which makes the loading/saving and usage of these models easier. The following changes are introduced:

- the `model` or `point_pred_model` argument in `__init__` becomes optional
- an optional parameter `prec_point_preds` is added to `ModelWithConfidence.fit`, `ModelWithConfidence.predict_confidence_of_point_prediction`, `ModelWithPredictionInterval.predict_interval` and `ModelWithPredictionInterval.fit`
-  an optional parameter `update_empirical_conflict_constant` is added to `_TrainingHelper.fit`. It allows to skip the step `find_conflicting_predictions`

Signed-off-by: Florent Rambaud <flo.rambaud@gmail.com>